### PR TITLE
Upgrade packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^5.4 | ^7.0"
+        "php": "^5.4 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
@@ -20,12 +20,13 @@
         "dhii/php-cs-fixer-config": "^0.1",
         "codeclimate/php-test-reporter": "<=0.3.2",
         "johnpbloch/wordpress-core": "^4.5",
-        "phpstan/phpstan-shim": "^0.11.12",
-        "szepeviktor/phpstan-wordpress": "^0.2.0"
+        "szepeviktor/phpstan-wordpress": "^0.3.0",
+        "phpstan/phpstan": "^0.11.19",
+        "php-stubs/wordpress-stubs": "^4.5"
     },
     "autoload": {
         "psr-4": {
-            "RebelCode\\Cronarchy\\": "src"
+            "RebelCode\\Cronarchy\\": "src/"
         }
     },
     "scripts": {


### PR DESCRIPTION
Please consider removing composer.lock

Tests will fail if you lock pkg versions (e.g. PHP 5.4 vs. 7.2)